### PR TITLE
Fix crashes on python 3.8, crash when launcher is not available, support multiple launcher prefixes per ide

### DIFF
--- a/data/IdeData.py
+++ b/data/IdeData.py
@@ -2,14 +2,17 @@
 
 
 # pylint: disable=too-few-public-methods
+from typing import List
+
+
 class IdeData:
     """ Class describing ide options"""
     name: str
     config_prefix: str
-    launcher_prefix: str
+    launcher_prefixes: List[str]
 
-    def __init__(self, name: str, config_prefix: str, launcher_prefix: str) -> None:
+    def __init__(self, name: str, config_prefix: str, launcher_prefixes: List[str]) -> None:
         super().__init__()
         self.name = name
         self.config_prefix = config_prefix
-        self.launcher_prefix = launcher_prefix
+        self.launcher_prefixes = launcher_prefixes

--- a/data/IdeData.py
+++ b/data/IdeData.py
@@ -1,10 +1,8 @@
 """ Contains IdeData class """
-
-
-# pylint: disable=too-few-public-methods
 from typing import List
 
 
+# pylint: disable=too-few-public-methods
 class IdeData:
     """ Class describing ide options"""
     name: str

--- a/data/IdeProject.py
+++ b/data/IdeProject.py
@@ -1,4 +1,5 @@
 """ Contains project type """
+from __future__ import annotations
 
 from data.IdeKey import IdeKey
 

--- a/events/KeywordQueryEventListener.py
+++ b/events/KeywordQueryEventListener.py
@@ -48,7 +48,7 @@ class KeywordQueryEventListener(EventListener):
 
         if ide_key is not None and extension.get_ide_launcher_script(ide_key):
             projects.extend(extension.get_recent_projects(ide_key))
-        else:
+        elif ide_key is None:
             for key in [key for key in extension.ides if extension.get_ide_launcher_script(key)]:
                 projects.extend(extension.get_recent_projects(cast(IdeKey, key)))
 

--- a/events/KeywordQueryEventListener.py
+++ b/events/KeywordQueryEventListener.py
@@ -66,18 +66,21 @@ class KeywordQueryEventListener(EventListener):
             return RenderResultListAction(results)
 
         for project in projects:
-            results.append(
-                ExtensionResultItem(
-                    icon=project.icon if project.icon is not None else
-                    extension.get_ide_icon(project.ide),
-                    name=project.name,
-                    description=project.path,
-                    on_enter=RunScriptAction(
-                        extension.get_ide_launcher_script(project.ide) +
-                        f' "{os.path.expanduser(project.path)}" &'
-                    ),
-                    on_alt_enter=CopyToClipboardAction(project.path)
+            try:
+                results.append(
+                    ExtensionResultItem(
+                        icon=project.icon if project.icon is not None else
+                        extension.get_ide_icon(project.ide),
+                        name=project.name,
+                        description=project.path,
+                        on_enter=RunScriptAction(
+                            extension.get_ide_launcher_script(project.ide) +
+                            f' "{os.path.expanduser(project.path)}" &'
+                        ),
+                        on_alt_enter=CopyToClipboardAction(project.path)
+                    )
                 )
-            )
+            except FileNotFoundError:
+                pass
 
         return RenderResultListAction(results)

--- a/events/KeywordQueryEventListener.py
+++ b/events/KeywordQueryEventListener.py
@@ -1,4 +1,5 @@
 """ Contains class for handling keyword events from Ulauncher"""
+from __future__ import annotations
 
 import os
 import re

--- a/events/KeywordQueryEventListener.py
+++ b/events/KeywordQueryEventListener.py
@@ -65,18 +65,25 @@ class KeywordQueryEventListener(EventListener):
             return RenderResultListAction(results)
 
         for project in projects:
-            results.append(
-                ExtensionResultItem(
-                    icon=project.icon if project.icon is not None else
-                    extension.get_ide_icon(project.ide),
-                    name=project.name,
-                    description=project.path,
-                    on_enter=RunScriptAction(
-                        extension.get_ide_launcher_script(project.ide),
-                        [project.path, "&"]
-                    ),
-                    on_alt_enter=CopyToClipboardAction(project.path)
+            try:
+                results.append(
+                    ExtensionResultItem(
+                        icon=project.icon if project.icon is not None else
+                        extension.get_ide_icon(project.ide),
+                        name=project.name,
+                        description=project.path,
+                        on_enter=RunScriptAction(
+                            extension.get_ide_launcher_script(project.ide),
+                            [project.path, "&"]
+                        ),
+                        on_alt_enter=CopyToClipboardAction(project.path)
+                    )
                 )
-            )
+            except FileNotFoundError:
+                results.append(ExtensionResultItem(
+                    name=project.name,
+                    description="Couldn't find launcher \"{}\" for this project".format(project.ide)
+                ))
+                pass
 
         return RenderResultListAction(results)

--- a/events/KeywordQueryEventListener.py
+++ b/events/KeywordQueryEventListener.py
@@ -1,4 +1,5 @@
 """ Contains class for handling keyword events from Ulauncher"""
+from __future__ import annotations
 
 import re
 from typing import cast

--- a/main.py
+++ b/main.py
@@ -1,7 +1,9 @@
 """ Ulauncher extension for opening recent projects on Jetbrains IDEs. """
+from __future__ import annotations
+
 import os
 import re
-from typing import cast
+from typing import Dict, cast
 
 import semver
 from ulauncher.api.client.Extension import Extension
@@ -18,7 +20,7 @@ from utils.RecentProjectsParser import RecentProjectsParser
 
 class JetbrainsLauncherExtension(Extension):
     """ Main Extension Class  """
-    ides: dict[IdeKey, IdeData] = {
+    ides: Dict[IdeKey, IdeData] = {
         "clion": IdeData(name="CLion", config_prefix="CLion", launcher_prefix="clion"),
         "idea": IdeData(name="IntelliJ IDEA", config_prefix="IntelliJIdea",
                         launcher_prefix="idea"),
@@ -30,7 +32,7 @@ class JetbrainsLauncherExtension(Extension):
                             launcher_prefix="webstorm")
     }
 
-    aliases: dict[str, IdeKey] = {}
+    aliases: Dict[str, IdeKey] = {}
 
     def __init__(self):
         """ Initializes the extension """
@@ -61,7 +63,7 @@ class JetbrainsLauncherExtension(Extension):
         if raw_aliases is None:
             return
 
-        matches = cast(list[tuple[str, str]], re.findall(r"(\w+):(?: +|)(\w+)*;", raw_aliases))
+        matches = re.findall(r"(\w+):(?: +|)(\w+)*;", raw_aliases)
 
         for alias, ide_key in matches:
             if self.check_ide_key(ide_key):

--- a/main.py
+++ b/main.py
@@ -21,15 +21,15 @@ from utils.RecentProjectsParser import RecentProjectsParser
 class JetbrainsLauncherExtension(Extension):
     """ Main Extension Class  """
     ides: Dict[IdeKey, IdeData] = {
-        "clion": IdeData(name="CLion", config_prefix="CLion", launcher_prefix="clion"),
+        "clion": IdeData(name="CLion", config_prefix="CLion", launcher_prefixes=["clion"]),
         "idea": IdeData(name="IntelliJ IDEA", config_prefix="IntelliJIdea",
-                        launcher_prefix="idea"),
+                        launcher_prefixes=["idea"]),
         "phpstorm": IdeData(name="PHPStorm", config_prefix="PHPStorm",
-                            launcher_prefix="phpstorm"),
-        "pycharm": IdeData(name="PyCharm", config_prefix="PyCharm", launcher_prefix="pycharm"),
-        "rider": IdeData(name="Rider", config_prefix="Rider", launcher_prefix="rider"),
+                            launcher_prefixes=["phpstorm"]),
+        "pycharm": IdeData(name="PyCharm", config_prefix="PyCharm", launcher_prefixes=["pycharm", "charm"]),
+        "rider": IdeData(name="Rider", config_prefix="Rider", launcher_prefixes=["rider"]),
         "webstorm": IdeData(name="WebStorm", config_prefix="WebStorm",
-                            launcher_prefix="webstorm")
+                            launcher_prefixes=["webstorm"])
     }
 
     aliases: Dict[str, IdeKey] = {}
@@ -168,11 +168,12 @@ class JetbrainsLauncherExtension(Extension):
         if ide_data is None:
             raise AttributeError("Invalid ide key specified")
 
-        path = os.path.join(os.path.expanduser(scripts_path), ide_data.launcher_prefix)
-        if path is None or not os.path.isfile(path):
-            raise FileNotFoundError(f"Cant find {ide_key} launcher script")
+        for prefix in ide_data.launcher_prefixes:
+            path = os.path.join(os.path.expanduser(scripts_path), prefix)
+            if path is not None and os.path.isfile(path):
+                return path
 
-        return path
+        raise FileNotFoundError(f"Cant find {ide_key} launcher script")
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -26,7 +26,8 @@ class JetbrainsLauncherExtension(Extension):
                         launcher_prefixes=["idea"]),
         "phpstorm": IdeData(name="PHPStorm", config_prefix="PHPStorm",
                             launcher_prefixes=["phpstorm"]),
-        "pycharm": IdeData(name="PyCharm", config_prefix="PyCharm", launcher_prefixes=["pycharm", "charm"]),
+        "pycharm": IdeData(name="PyCharm", config_prefix="PyCharm",
+                           launcher_prefixes=["pycharm", "charm"]),
         "rider": IdeData(name="Rider", config_prefix="Rider", launcher_prefixes=["rider"]),
         "webstorm": IdeData(name="WebStorm", config_prefix="WebStorm",
                             launcher_prefixes=["webstorm"])
@@ -153,7 +154,7 @@ class JetbrainsLauncherExtension(Extension):
 
         return path
 
-    def get_ide_launcher_script(self, ide_key: IdeKey) -> str:
+    def get_ide_launcher_script(self, ide_key: IdeKey) -> str | None:
         """
         Gets path to the IDE launcher script for specified key
         :param ide_key: IDE key
@@ -173,7 +174,7 @@ class JetbrainsLauncherExtension(Extension):
             if path is not None and os.path.isfile(path):
                 return path
 
-        raise FileNotFoundError(f"Cant find {ide_key} launcher script")
+        return None
 
 
 if __name__ == "__main__":

--- a/utils/ProjectsList.py
+++ b/utils/ProjectsList.py
@@ -1,5 +1,5 @@
 """ Contains custom implementation of SortedList found in Ulauncher's code """
-from typing import Iterator
+from typing import Iterator, List
 
 from ulauncher.utils.SortedCollection import SortedCollection  # type: ignore
 from ulauncher.utils.fuzzy_search import get_score  # type: ignore
@@ -44,7 +44,7 @@ class ProjectsList:
     def __contains__(self, item: IdeProject) -> bool:
         return item in self._items
 
-    def extend(self, items: list[IdeProject]) -> None:
+    def extend(self, items: List[IdeProject]) -> None:
         """
         Merges all provided items into this list
         :param items: A list of items to merge

--- a/utils/RecentProjectsParser.py
+++ b/utils/RecentProjectsParser.py
@@ -3,7 +3,7 @@
 import glob
 import os
 from collections import OrderedDict
-from typing import Optional, cast
+from typing import Optional, cast, List
 from xml.etree import ElementTree
 
 from data.IdeKey import IdeKey
@@ -15,7 +15,7 @@ class RecentProjectsParser:
     """ Parser for JetBrains IDEs "Recent projects" files """
 
     @staticmethod
-    def parse(file_path: str, ide_key: IdeKey) -> list[IdeProject]:
+    def parse(file_path: str, ide_key: IdeKey) -> List[IdeProject]:
         """
         Parses the "Recent projects" file
         :param file_path: The path to the file


### PR DESCRIPTION
Hi!

In this PR I added/fixed the following:

* Fixed the type annotations (I don't know how it even ran for you, but I wasn't able to get it to work on Python 3.8)
* Imported ` from __future__ import annotations` every time something like `str | None` is used as type annotation since also doesn't seem to work on Python 3.8
* Wrapped the result generating block in try/except to show an error to the user if no launcher could be found for a project, instead of staying stuck at "loading" and showing no error at all
* Added support for multiple prefixes per ide, since when creating a command-line launcher for pycharm from within pycharm, it is named "charm" by default (I'm not sure how Jetbrains Toolbox behaves, I'm not using that)