### PR TITLE
fix: run script opening recent project screen instead of selected project

### DIFF
--- a/events/KeywordQueryEventListener.py
+++ b/events/KeywordQueryEventListener.py
@@ -71,8 +71,7 @@ class KeywordQueryEventListener(EventListener):
                     name=project.name,
                     description=project.path,
                     on_enter=RunScriptAction(
-                        extension.get_ide_launcher_script(project.ide),
-                        [project.path, "&"]
+                        '{} "{}" &'.format(extension.get_ide_launcher_script(project.ide), project.path)
                     ),
                     on_alt_enter=CopyToClipboardAction(project.path)
                 )


### PR DESCRIPTION
Hi, 

when I try to launch a project in any IDE, it doesn't actually launch that specific project, but rather the last opened project.
I reverted the `RunScriptAction` command to the way it is done in `ulauncher-jetbrains` (https://github.com/brpaz/ulauncher-jetbrains/blob/master/main.py#L85, just updated to the new format syntax), and now it works (at least for me). 