### PR TITLE
fix: custom project names not resolved correctly

### DIFF
--- a/events/KeywordQueryEventListener.py
+++ b/events/KeywordQueryEventListener.py
@@ -71,7 +71,7 @@ class KeywordQueryEventListener(EventListener):
                     name=project.name,
                     description=project.path,
                     on_enter=RunScriptAction(
-                        '{} "{}" &'.format(extension.get_ide_launcher_script(project.ide), project.path)
+                        f'{extension.get_ide_launcher_script(project.ide)} "{project.path}" &'
                     ),
                     on_alt_enter=CopyToClipboardAction(project.path)
                 )

--- a/utils/RecentProjectsParser.py
+++ b/utils/RecentProjectsParser.py
@@ -52,14 +52,15 @@ class RecentProjectsParser:
 
         output = []
         for path in project_paths:
-            name_file = path + '/.idea/.name'
+            full_path = os.path.expanduser(path)
+            name_file = full_path + '/.idea/.name'
             name = ''
 
             if os.path.exists(name_file):
                 with open(name_file, 'r', encoding="utf8") as file:
                     name = file.read().replace('\n', '')
 
-            icons = glob.glob(os.path.join(os.path.expanduser(path), '.idea', 'icon.*'))
+            icons = glob.glob(os.path.join(full_path, '.idea', 'icon.*'))
 
             output.append(IdeProject(
                 name=name or os.path.basename(path),


### PR DESCRIPTION
In this PR I've fixed an issue causing **custom project names** to not be properly resolved.

It was caused by a `non-absolute` path to the `.idea/.name` file, which lead to the file being flagged as non-existing and defaulting to the project basename.