### PR TITLE
fix: invalid project being opened by the IDE

### DIFF
--- a/events/KeywordQueryEventListener.py
+++ b/events/KeywordQueryEventListener.py
@@ -1,5 +1,6 @@
 """ Contains class for handling keyword events from Ulauncher"""
 
+import os
 import re
 from typing import cast
 
@@ -71,7 +72,8 @@ class KeywordQueryEventListener(EventListener):
                     name=project.name,
                     description=project.path,
                     on_enter=RunScriptAction(
-                        f'{extension.get_ide_launcher_script(project.ide)} "{project.path}" &'
+                        extension.get_ide_launcher_script(project.ide) +
+                        f' "{os.path.expanduser(project.path)}" &'
                     ),
                     on_alt_enter=CopyToClipboardAction(project.path)
                 )


### PR DESCRIPTION
This PR fixes issue causing IDE to open an **invalid project** when selecting a result.

This is caused by escaping the project path using double quotes while using a `non-absolute` path.
Apparently, the IDE launch script ignores the `~/` variable when surrounded by the double quotes and instead launches a project relative to the current directory. So to fix that I've made the path `absolute` this way the path is properly resolved while preserving the double-quote escaping to support paths with spaces and other weird characters.