### PR TITLE
fix: alias matching for ide keys containing hyphens

### DIFF
--- a/main.py
+++ b/main.py
@@ -72,7 +72,7 @@ class JetbrainsLauncherExtension(Extension):
         if raw_aliases is None:
             return
 
-        matches = re.findall(r"(\w+):(?: +|)(\w+)*;", raw_aliases)
+        matches = re.findall(r"(\w+):(?: +|)([\w-]+)*;", raw_aliases)
 
         for alias, ide_key in matches:
             if self.check_ide_key(ide_key):


### PR DESCRIPTION
This PR fixes a small bug introduced in #7 causing the `parse_aliases()` method to not match IDE keys containing hyphens.
Example: `android-studio` didn't work before.