### PR TITLE
feat: add sorting based on timestamp on default queries

### DIFF
--- a/data/IdeProject.py
+++ b/data/IdeProject.py
@@ -10,15 +10,18 @@ class IdeProject:
     name: str
     ide: IdeKey
     path: str
-    score: int
+    timestamp: int | None
     icon: str | None
+    score: int
 
     # pylint: disable=too-many-arguments
-    def __init__(self, name: str, ide: IdeKey, path: str, score: int,
-                 icon: str | None = None) -> None:
+    def __init__(self, name: str, ide: IdeKey, path: str,
+                 timestamp: int | None, icon: str | None = None) -> None:
         super().__init__()
-        self.icon = icon
-        self.score = score
-        self.path = path
-        self.ide = ide
+
         self.name = name
+        self.ide = ide
+        self.path = path
+        self.timestamp = timestamp
+        self.icon = icon
+        self.score = 0

--- a/utils/ProjectsList.py
+++ b/utils/ProjectsList.py
@@ -25,7 +25,8 @@ class ProjectsList:
         self._limit = limit
         self._items = SortedCollection(
             key=lambda item:
-            -item.timestamp if not self._query else item.score
+            (-item.timestamp if item.timestamp is not None else 0)
+            if not self._query else item.score
         )
 
     def __len__(self) -> int:

--- a/utils/ProjectsList.py
+++ b/utils/ProjectsList.py
@@ -23,7 +23,10 @@ class ProjectsList:
         self._query = query.lower().strip()
         self._min_score = min_score
         self._limit = limit
-        self._items = SortedCollection(key=lambda item: item.score)
+        self._items = SortedCollection(
+            key=lambda item:
+            -item.timestamp if not self._query else item.score
+        )
 
     def __len__(self) -> int:
         return len(self._items)
@@ -60,13 +63,19 @@ class ProjectsList:
         name = item.name
         path = item.path.replace(r"^~", "")
 
-        score = max(get_score(self._query, name), get_score(self._query, path))
-
-        if score >= self._min_score:
-            # use negative to sort by score in desc. order
-            item.score = -score
-
+        if not self._query:
             self._items.insert(item)
+
             while len(self._items) > self._limit:
-                # remove items with the lowest score to maintain limited number of items
                 self._items.pop()
+        else:
+            score = max(get_score(self._query, name), get_score(self._query, path))
+
+            if score >= self._min_score:
+                # use negative to sort by score in desc. order
+                item.score = -score
+
+                self._items.insert(item)
+                while len(self._items) > self._limit:
+                    # remove items with the lowest score to maintain limited number of items
+                    self._items.pop()

--- a/utils/RecentProjectsParser.py
+++ b/utils/RecentProjectsParser.py
@@ -2,12 +2,14 @@
 
 import glob
 import os
-from collections import OrderedDict
-from typing import Optional, cast, List
+from typing import Optional, cast, List, TypedDict
 from xml.etree import ElementTree
+from xml.etree.ElementTree import Element
 
 from data.IdeKey import IdeKey
 from data.IdeProject import IdeProject
+
+EntryData = TypedDict("EntryData", {"path": str, "timestamp": Optional[int]})
 
 TIMESTAMP_XML_PATH = 'value/RecentProjectMetaInfo/option[@name="projectOpenTimestamp"]'
 RECENT_PROJECTS_MANAGER_PATH = './/component[@name="RecentProjectsManager"][1]'
@@ -50,15 +52,37 @@ class RecentProjectsParser:
                 f'{RECENT_PROJECTS_MANAGER_PATH}/option[@name="groups"]/list/ProjectGroup/' +
                 'option[@name="projects"]/list/option'
             )
-        project_paths = list(OrderedDict.fromkeys([
-            (project.attrib['value' if 'value' in project.attrib else 'key']).replace(
-                "$USER_HOME$", "~"
+
+        projects: List[EntryData] = [
+            cast(
+                EntryData,
+                {
+                    "path": (
+                        project.attrib['value' if 'value' in project.attrib else 'key'])
+                        .replace("$USER_HOME$", "~"),
+                    "timestamp": (
+                        int(cast(Element, project.find(TIMESTAMP_XML_PATH)).attrib["value"])
+                        if project.find(TIMESTAMP_XML_PATH) is not None else None
+                    ) if project.tag == "entry" else None
+                }
             ) for project in raw_projects
-        ]))
+        ]
+
+        filtered: List[EntryData] = []
+        for project in projects:
+            index = next(
+                (index for index, d in enumerate(filtered) if d["path"] == project["path"]),
+                None
+            )
+
+            if index is None:
+                filtered.append(project)
+            elif index is not None and project["timestamp"] is not None:
+                filtered[index]["timestamp"] = project["timestamp"]
 
         output = []
-        for path in project_paths:
-            full_path = os.path.expanduser(path)
+        for data in filtered:
+            full_path = os.path.expanduser(data["path"])
             name_file = full_path + '/.idea/.name'
             name = ''
 
@@ -69,11 +93,11 @@ class RecentProjectsParser:
             icons = glob.glob(os.path.join(full_path, '.idea', 'icon.*'))
 
             output.append(IdeProject(
-                name=name or os.path.basename(path),
-                path=path,
+                name=name or os.path.basename(data["path"]),
+                ide=ide_key,
+                path=data["path"],
+                timestamp=data["timestamp"],
                 icon=cast(Optional[str], icons[0] if len(icons) > 0 else None),
-                score=0,
-                ide=ide_key
             ))
 
         return output

--- a/utils/RecentProjectsParser.py
+++ b/utils/RecentProjectsParser.py
@@ -9,6 +9,11 @@ from xml.etree import ElementTree
 from data.IdeKey import IdeKey
 from data.IdeProject import IdeProject
 
+TIMESTAMP_XML_PATH = 'value/RecentProjectMetaInfo/option[@name="projectOpenTimestamp"]'
+RECENT_PROJECTS_MANAGER_PATH = './/component[@name="RecentProjectsManager"][1]'
+RECENT_DIRECTORY_PROJECTS_MANAGER_PATH = \
+    './/component[@name="RecentDirectoryProjectsManager"][1]'
+
 
 # pylint: disable=too-few-public-methods
 class RecentProjectsParser:
@@ -27,22 +32,23 @@ class RecentProjectsParser:
             return []
 
         root = ElementTree.parse(file_path).getroot()
-        recent_projects_manager_path = './/component[@name="RecentProjectsManager"][1]'
-        recent_directory_projects_manager_path = \
-            './/component[@name="RecentDirectoryProjectsManager"][1]'
 
         raw_projects = \
             root.findall(
-                f'{recent_projects_manager_path}/option[@name="recentPaths"]/list/option'
+                f'{RECENT_PROJECTS_MANAGER_PATH}/option[@name="recentPaths"]/list/option'
             ) + \
             root.findall(
-                f'{recent_directory_projects_manager_path}/option[@name="recentPaths"]/list/option'
+                f'{RECENT_DIRECTORY_PROJECTS_MANAGER_PATH}/option[@name="recentPaths"]/list/option'
             ) + \
             root.findall(
-                f'{recent_projects_manager_path}/option[@name="additionalInfo"]/map/entry'
+                f'{RECENT_PROJECTS_MANAGER_PATH}/option[@name="additionalInfo"]/map/entry'
             ) + \
             root.findall(
-                f'{recent_directory_projects_manager_path}/option[@name="additionalInfo"]/map/entry'
+                f'{RECENT_DIRECTORY_PROJECTS_MANAGER_PATH}/option[@name="additionalInfo"]/map/entry'
+            ) + \
+            root.findall(
+                f'{RECENT_PROJECTS_MANAGER_PATH}/option[@name="groups"]/list/ProjectGroup/' +
+                'option[@name="projects"]/list/option'
             )
         project_paths = list(OrderedDict.fromkeys([
             (project.attrib['value' if 'value' in project.attrib else 'key']).replace(


### PR DESCRIPTION
This PR adds the ability to sort recent projects by their `timestamp` value when the `query` is empty (default).
This is directly inspired by the brpaz/ulauncher-jetbrains#33.