### PR TITLE
feat: add support for Rider's recentSolutions.xml file

### DIFF
--- a/main.py
+++ b/main.py
@@ -140,11 +140,22 @@ class JetbrainsLauncherExtension(Extension):
             return []
 
         version = max(versions)
+        config_dir = os.path.join(
+            base_path,
+            f"{ide_data.config_prefix}{version.major}.{version.minor}",
+            "options"
+        )
+
         projects = RecentProjectsParser.parse(
-            os.path.join(base_path, f"{ide_data.config_prefix}{version.major}.{version.minor}",
-                         "options", "recentProjects.xml"),
+            os.path.join(config_dir, "recentProjects.xml"),
             ide_key
         )
+
+        if ide_key == "rider":
+            projects += RecentProjectsParser.parse(
+                os.path.join(config_dir, "recentSolutions.xml"),
+                ide_key
+            )
 
         return projects
 


### PR DESCRIPTION
This PR adds support for Rider's `recentSolutions.xml` file.
This is directly inspired by the brpaz/ulauncher-jetbrains#14.

Looking at the file generated by Rider IDE version `2021.3.3` it looks similar to the `recentProjects.xml` file, the only notable change is that the main `component` element has the `RiderRecentProjectsManager` name instead of `RecentProjectsManager`

```diff
- <component name="RecentProjectsManager">
+ <component name="RiderRecentProjectsManager">
```
So while implementing I've assumed that the XML structure is the same as in the `recentProjects.xml` file.
It's also worth noting that from my testing it seems that this file replaced the `recentProjects.xml` file because even projects imported as `directory` are saved to it.