### PR TITLE
Support multiple IDE prefixes, ignore versions without a recent projects file

### DIFF
--- a/data/IdeData.py
+++ b/data/IdeData.py
@@ -8,14 +8,16 @@ from typing import List
 class IdeData:
     """ Class describing ide options"""
     name: str
-    config_prefix: str
+    config_prefixes: [str]
     launcher_prefixes: List[str]
     custom_config_key: str | None
+    recent_projects_file: str
 
-    def __init__(self, name: str, config_prefix: str, launcher_prefixes: List[str],
-                 custom_config_key: str | None = None) -> None:
+    def __init__(self, name: str, config_prefixes: [str], launcher_prefixes: List[str],
+                 custom_config_key: str | None = None, recent_projects_file: str = "recentProjects.xml") -> None:
         super().__init__()
         self.name = name
-        self.config_prefix = config_prefix
+        self.config_prefixes = config_prefixes
         self.launcher_prefixes = launcher_prefixes
         self.custom_config_key = custom_config_key
+        self.recent_projects_file = recent_projects_file

--- a/main.py
+++ b/main.py
@@ -158,10 +158,10 @@ class JetbrainsLauncherExtension(Extension):
         if len(versions) == 0:
             return []
 
-        version = max(versions, key=versions.get)
+        directory = max(versions, key=versions.get)
         config_dir = os.path.join(
             base_path,
-            version,
+            directory,
             "options"
         )
 

--- a/main.py
+++ b/main.py
@@ -26,7 +26,7 @@ class JetbrainsLauncherExtension(Extension):
                         launcher_prefixes=["idea"]),
         "phpstorm": IdeData(name="PHPStorm", config_prefixes=["PhpStorm"],
                             launcher_prefixes=["phpstorm", "pstorm"]),
-        "pycharm": IdeData(name="PyCharm", config_prefixes=["PyCharm"],
+        "pycharm": IdeData(name="PyCharm", config_prefixes=["PyCharm", "PyCharmCE"],
                            launcher_prefixes=["pycharm", "charm"]),
         "rider": IdeData(name="Rider", config_prefixes=["Rider"], launcher_prefixes=["rider"],
                          recent_projects_file="recentSolutions.xml"),


### PR DESCRIPTION
This PR fixes two issues I have experienced with this extension:

1. When using the IntelliJ IDEA Community Edition, projects do not show up because the config prefix is different from the ultimate edition.
To fix this, I introduced the option of having multiple prefixes for an IDE. This means that you can't use both community and ultimate edition at the same time, but matches the behavior with the PyCharm Community vs. Professional Edition.

2. When you update an IDE, the recentProjects file is not copied until you start it, but the folder already exists. This causes the extension to show no projects for the IDE.
To fix this, I ignored all IDE folders that don't include the recent projects file.